### PR TITLE
fix: make `unreliable_regions.csv` header compatible with iimi

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -153,6 +153,7 @@ process build_xgb_model {
 
   script:
   """
- Rscript ${build_iimi_model_r} . ${unreliable_regions} ${iimi_sequence_info} ${sample_viruses}
- """
+  sed -i '1 s/sequence_id/Virus segment/' ${unreliable_regions}
+  Rscript ${build_iimi_model_r} . ${unreliable_regions} ${iimi_sequence_info} ${sample_viruses}
+  """
 }


### PR DESCRIPTION
Change `sequence_id` column name to `Virus segment` when training.
